### PR TITLE
Fixed popover view controller of Share button on iPad

### DIFF
--- a/AnimojiStudio.xcodeproj/project.pbxproj
+++ b/AnimojiStudio.xcodeproj/project.pbxproj
@@ -570,7 +570,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = CUCB33MFQZ;
+				DEVELOPMENT_TEAM = WX9732WYH7;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AnimojiStudio/AvatarKit",
@@ -579,7 +579,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/AnimojiStudio/Resources/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = fun.Animoji;
+				PRODUCT_BUNDLE_IDENTIFIER = fun.AnimojiStudio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SYSTEM_FRAMEWORK_SEARCH_PATHS = "";
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = CUCB33MFQZ;
+				DEVELOPMENT_TEAM = WX9732WYH7;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AnimojiStudio/AvatarKit",
@@ -603,7 +603,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/AnimojiStudio/Resources/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = AnimojiStudio;
+				PRODUCT_BUNDLE_IDENTIFIER = fun.AnimojiStudio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SYSTEM_FRAMEWORK_SEARCH_PATHS = "";

--- a/AnimojiStudio.xcodeproj/project.pbxproj
+++ b/AnimojiStudio.xcodeproj/project.pbxproj
@@ -570,7 +570,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = WX9732WYH7;
+				DEVELOPMENT_TEAM = CUCB33MFQZ;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AnimojiStudio/AvatarKit",
@@ -579,7 +579,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/AnimojiStudio/Resources/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = fun.AnimojiStudio;
+				PRODUCT_BUNDLE_IDENTIFIER = fun.Animoji;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SYSTEM_FRAMEWORK_SEARCH_PATHS = "";
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = WX9732WYH7;
+				DEVELOPMENT_TEAM = CUCB33MFQZ;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AnimojiStudio/AvatarKit",
@@ -603,7 +603,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/AnimojiStudio/Resources/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = fun.AnimojiStudio;
+				PRODUCT_BUNDLE_IDENTIFIER = AnimojiStudio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SYSTEM_FRAMEWORK_SEARCH_PATHS = "";

--- a/AnimojiStudio/Controllers/Sharing/SharingFlowController.m
+++ b/AnimojiStudio/Controllers/Sharing/SharingFlowController.m
@@ -61,7 +61,7 @@
         
         [weakSelf done:nil];
     }];
-    
+    activityController.popoverPresentationController.sourceView = self.previewController.shareButton;
     [self presentViewController:activityController animated:YES completion:nil];
 }
 

--- a/AnimojiStudio/Controllers/Sharing/VideoPreviewViewController.h
+++ b/AnimojiStudio/Controllers/Sharing/VideoPreviewViewController.h
@@ -7,7 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
-
+@class BigButton;
 @class VideoPreviewViewController;
 
 @protocol VideoPreviewDelegate <NSObject>
@@ -17,7 +17,7 @@
 @end
 
 @interface VideoPreviewViewController : UIViewController
-
+@property (nonatomic, strong) BigButton *shareButton;
 @property (nonatomic, weak) id<VideoPreviewDelegate> delegate;
 
 @property (nonatomic, copy) NSURL *videoURL;

--- a/AnimojiStudio/Controllers/Sharing/VideoPreviewViewController.m
+++ b/AnimojiStudio/Controllers/Sharing/VideoPreviewViewController.m
@@ -22,7 +22,6 @@
 @property (nonatomic, strong) AVPlayerLayer *videoLayer;
 
 @property (nonatomic, strong) UIView *videoView;
-@property (nonatomic, strong) BigButton *shareButton;
 
 @end
 


### PR DESCRIPTION
The "Share your creation" button would crash on iPad, since UIActivityViewController uses a popover presentation on iPad.

Fix : set activityController.popoverPresentationController.sourceView to shareButton (and moved sharedButton to the public interface in the process).